### PR TITLE
[CHORE] Build for introspection

### DIFF
--- a/Introspect.xcodeproj/project.pbxproj
+++ b/Introspect.xcodeproj/project.pbxproj
@@ -767,6 +767,7 @@
 		C0687027238DE85D00DAFD3D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -796,6 +797,7 @@
 		C0687028238DE85D00DAFD3D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
## Context

Add "Build libraries for distribution" which hopefully will stop the transferwiser-ios build breaking every new release of Xcode (and it's version of swift)

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
