### PR TITLE
Turn on build library for distribution

### DIFF
--- a/Introspect.xcodeproj/project.pbxproj
+++ b/Introspect.xcodeproj/project.pbxproj
@@ -767,6 +767,7 @@
 		C0687027238DE85D00DAFD3D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -796,6 +797,7 @@
 		C0687028238DE85D00DAFD3D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
## Context

I am turning on Xcode's 'Build library for distribution' flag in the vain hope that this will stop the compilation errors every time we move to a new version of XCode (and hence the swift language)

Hopefully, we will have no more 'Failed to build module 'Introspect'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 5.7', while this compiler is 'Apple Swift version 5.7.1 )'.  errors


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
